### PR TITLE
include cop for alphabetically ordered fields and arguments in graphql

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -39,8 +39,6 @@ GraphQL/FieldDescription: { Enabled: false }
 GraphQL/FieldName: { Enabled: false }
 GraphQL/FieldMethod: { Enabled: true, AutoCorrect: false }
 GraphQL/ObjectDescription: { Enabled: false }
-GraphQL/OrderedArguments: { Enabled: false }
-GraphQL/OrderedFields: { Enabled: false }
 
 Lint/AssignmentInCondition: { Enabled: true, AllowSafeAssignment: false }
 Lint/SafeNavigationChain:


### PR DESCRIPTION
This will force alphabetically ordered arguments and fields. I originally disabled it to reduce thrash as we rolled out rubocop, but I think we actually want this for complex types with lots of fields and arguments, as it makes it easier to find things. 