### PR TITLE
Add Custom Cop for Preventing `instance_variable_get` and `instance_variable_set`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,10 +3,15 @@ Angellist:
 
 Angellist/NoUnless:
   Enabled: true
-  Description: 'Always prefer `if` over `unless`.'
-  VersionAdded: '1.0.0'
+  Description: "Always prefer `if` over `unless`."
+  VersionAdded: "1.0.0"
 
 Angellist/PreferDateCurrent:
-  Description: 'Prefer Date.current over Time.zone.today'
+  Description: "Prefer Date.current over Time.zone.today"
   Enabled: true
-  VersionAdded: '1.0.2'
+  VersionAdded: "1.0.2"
+
+Angellist/ForbidInstanceVariableGet:
+  Description: "Forbids the use of instance_variable_get and instance_variable_set"
+  Enabled: true
+  VersionAdded: "1.0.3"

--- a/config/default.yml
+++ b/config/default.yml
@@ -13,5 +13,5 @@ Angellist/PreferDateCurrent:
 
 Angellist/ForbidInstanceVariableGetSet:
   Description: "Forbids the use of instance_variable_get and instance_variable_set"
-  Enabled: true
+  Enabled: false
   VersionAdded: "1.0.3"

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,7 +11,7 @@ Angellist/PreferDateCurrent:
   Enabled: true
   VersionAdded: "1.0.2"
 
-Angellist/ForbidInstanceVariableGet:
+Angellist/ForbidInstanceVariableGetSet:
   Description: "Forbids the use of instance_variable_get and instance_variable_set"
   Enabled: true
   VersionAdded: "1.0.3"

--- a/lib/rubocop/cop/angellist/forbid_instance_variable_get.rb
+++ b/lib/rubocop/cop/angellist/forbid_instance_variable_get.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module AngelList
+      # This cop forbids the use of `instance_variable_get` and `instance_variable_set`.
+      # These methods bypass encapsulation and make code harder to reason about.
+      #
+      # @example
+      #   # bad
+      #   object.instance_variable_get(:@foo)
+      #   object.instance_variable_set(:@foo, value)
+      #
+      #   # good
+      #   object.foo
+      #   object.foo = value
+      #
+      class ForbidInstanceVariableGet < Base
+        MSG = 'Avoid using `instance_variable_get` or `instance_variable_set`. Prefer using public getters/setters.'
+
+        RESTRICT_ON_SEND = %i[instance_variable_get instance_variable_set].freeze
+
+        def on_send(node)
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/angellist/forbid_instance_variable_get_set.rb
+++ b/lib/rubocop/cop/angellist/forbid_instance_variable_get_set.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   object.foo
       #   object.foo = value
       #
-      class ForbidInstanceVariableGet < Base
+      class ForbidInstanceVariableGetSet < Base
         MSG = 'Avoid using `instance_variable_get` or `instance_variable_set`. Prefer using public getters/setters.'
 
         RESTRICT_ON_SEND = %i[instance_variable_get instance_variable_set].freeze

--- a/lib/rubocop/cop/angellist_cops.rb
+++ b/lib/rubocop/cop/angellist_cops.rb
@@ -3,4 +3,4 @@
 
 require_relative 'angellist/no_unless'
 require_relative 'angellist/prefer_date_current'
-require_relative 'angellist/forbid_instance_variable_get'
+require_relative 'angellist/forbid_instance_variable_get_set'

--- a/lib/rubocop/cop/angellist_cops.rb
+++ b/lib/rubocop/cop/angellist_cops.rb
@@ -3,3 +3,4 @@
 
 require_relative 'angellist/no_unless'
 require_relative 'angellist/prefer_date_current'
+require_relative 'angellist/forbid_instance_variable_get'

--- a/spec/rubocop/cop/angellist/forbid_instance_variable_get_set_spec.rb
+++ b/spec/rubocop/cop/angellist/forbid_instance_variable_get_set_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::AngelList::ForbidInstanceVariableGetSet, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using instance_variable_get' do
+    expect_offense(<<~RUBY)
+      object.instance_variable_get(:@foo)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AngelList/ForbidInstanceVariableGetSet: Avoid using `instance_variable_get` or `instance_variable_set`. Prefer using public getters/setters.
+    RUBY
+  end
+
+  it 'registers an offense when using instance_variable_set' do
+    expect_offense(<<~RUBY)
+      object.instance_variable_set(:@foo, value)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AngelList/ForbidInstanceVariableGetSet: Avoid using `instance_variable_get` or `instance_variable_set`. Prefer using public getters/setters.
+    RUBY
+  end
+
+  it 'does not register an offense when using regular getters' do
+    expect_no_offenses(<<~RUBY)
+      object.foo
+    RUBY
+  end
+
+  it 'does not register an offense when using regular setters' do
+    expect_no_offenses(<<~RUBY)
+      object.foo = value
+    RUBY
+  end
+
+  it 'registers an offense when using instance_variable_get with string argument' do
+    expect_offense(<<~RUBY)
+      object.instance_variable_get("@foo")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AngelList/ForbidInstanceVariableGetSet: Avoid using `instance_variable_get` or `instance_variable_set`. Prefer using public getters/setters.
+    RUBY
+  end
+
+  it 'registers an offense when using instance_variable_set with string argument' do
+    expect_offense(<<~RUBY)
+      object.instance_variable_set("@foo", value)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AngelList/ForbidInstanceVariableGetSet: Avoid using `instance_variable_get` or `instance_variable_set`. Prefer using public getters/setters.
+    RUBY
+  end
+end 


### PR DESCRIPTION
We generally don't want to allow this type of meta programming. This PR adds a custom rule so we can enforce it on a linter level.