### PR TITLE
more aggressive default sigils for sorbet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-angellist (1.1.0)
+    rubocop-angellist (1.1.1)
       lint_roller
       rubocop (>= 1.72.0)
       rubocop-graphql (>= 1.5.5)

--- a/lib/rubocop/angellist/version.rb
+++ b/lib/rubocop/angellist/version.rb
@@ -3,6 +3,6 @@
 
 module RuboCop
   module Angellist
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -66,8 +66,8 @@ Sorbet/EnforceSigilOrder: { Enabled: false }
 Sorbet/FalseSigil: { Enabled: false }
 Sorbet/HasSigil:
   Enabled: true
-  SuggestedStrictness: 'true'
-  MinimumStrictness: 'false'
+  SuggestedStrictness: 'strict'
+  MinimumStrictness: 'true'
 
 Style/BlockDelimiters: { Enabled: true }
 Style/CommentAnnotation: { Enabled: false }


### PR DESCRIPTION
Makes the default sigil for existing files `true` and new files `strict`. This could add some friction for eng when touching pretty old gnarly files, so I'd be open to keeping the min `false`. But idk, since it's easy to swap `true` -> `false` in really bad files.  